### PR TITLE
GraphObject.Vertex() passes arguments correctly to GraphObject.V()

### DIFF
--- a/pyley/__init__.py
+++ b/pyley/__init__.py
@@ -75,7 +75,7 @@ class GraphObject(object):
         if len(node_ids) == 0:
             return self.V()
 
-        return self.V(node_ids)
+        return self.V(*node_ids)
 
     def Morphism(self):
         return self.M()


### PR DESCRIPTION
Previously, calling g.Vertex("Humphrey Bogart').All() (or any call to g.Vertex() with one or more argument) produced an incorrect query string e.g. "g.V('('Humphrey Bogart',)').All()". This was due to all arguments to g.Vertex() being passed as a tuple to g.V(). g.V('Humphrey Bogart') works correctly. Changing how Vertex() passes the arguments to V() fixes this. (Thanks to @joshainglis )