### PR TITLE
Support write and delete

### DIFF
--- a/pyley/__init__.py
+++ b/pyley/__init__.py
@@ -24,6 +24,8 @@ class CayleyResponse(object):
 class CayleyClient(object):
     def __init__(self, url="http://localhost:64210", version="v1"):
         self.url = "%s/api/%s/query/gizmo" % (url, version)
+        self.write_url = "%s/api/%s/write" % (url, version)
+        self.delete_url = "%s/api/%s/delete" % (url, version)
 
     def Send(self, query):
         if isinstance(query, str):
@@ -34,6 +36,38 @@ class CayleyClient(object):
             return CayleyResponse(r, r.json())
         else:
             raise Exception("Invalid query parameter in Send")
+
+    def AddQuad(self, subject, predicate, object_, label=None):
+        return self.AddQuads([(subject, predicate, object_, label)])
+
+    def AddQuads(self, quads):
+        quads = [
+            {
+                "subject": q[0],
+                "predicate": q[1],
+                "object": q[2],
+                "label": None if len(q) < 4 else q[3]
+            }
+            for q in quads
+        ]
+        r = requests.post(self.write_url, json=quads)
+        return CayleyResponse(r, r.json())
+
+    def DeleteQuad(self, subject, predicate, object_, label=None):
+        return self.DeleteQuads([(subject, predicate, object_, label)])
+
+    def DeleteQuads(self, quads):
+        quads = [
+            {
+                "subject": q[0],
+                "predicate": q[1],
+                "object": q[2],
+                "label": None if len(q) < 4 else q[3]
+            }
+            for q in quads
+        ]
+        r = requests.post(self.delete_url, json=quads)
+        return CayleyResponse(r, r.json())
 
 
 class _GremlinQuery(object):

--- a/tests/test_cayley_client.py
+++ b/tests/test_cayley_client.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
-import unittest
 from pyley import CayleyClient, GraphObject
+
+_CLIENT_URL = 'http://localhost:64210'
 
 
 class CayleyClientTests(TestCase):
-    @unittest.skip('Disabled for now!')
     def test_send(self):
-        client = CayleyClient()
+        client = CayleyClient(_CLIENT_URL)
         g = GraphObject()
         query = g.V().Has("name", "Casablanca") \
             .Out("/film/film/starring") \
@@ -15,8 +15,60 @@ class CayleyClientTests(TestCase):
             .All()
         response = client.Send(query)
 
-        print response.result
-
         self.assertTrue(response.r.status_code == 200)
         self.assertTrue(response.r is not None)
         self.assertTrue(len(response.result) > 0)
+
+    def test_a_add_quad(self):
+        client = CayleyClient(_CLIENT_URL)
+        response = client.AddQuad('foo', 'to', 'bar')
+        self.assertEqual(response.r.status_code, 200)
+
+        g = GraphObject()
+        query = g.V("foo").Out('to').Is('bar').All()
+        response = client.Send(query)
+        self.assertEqual(len(response.result['result']), 1)
+
+    def test_b_delete_quad(self):
+        client = CayleyClient(_CLIENT_URL)
+        response = client.DeleteQuad('foo', 'to', 'bar')
+        self.assertEqual(response.r.status_code, 200)
+
+        g = GraphObject()
+
+        query = g.V("foo").Out('to').Is("bar").All()
+        response = client.Send(query)
+        self.assertIsNone(response.result['result'])
+
+    def test_c_add_quads(self):
+        client = CayleyClient(_CLIENT_URL)
+        response = client.AddQuads([
+            ('foo', 'to', 'bar'),
+            ('baz', 'from', 'quux')
+        ])
+        self.assertEqual(response.r.status_code, 200)
+
+        g = GraphObject()
+
+        query = g.V("foo").Out('to').Is("bar").Union(
+            g.V("baz").Out('from').Is("quux")
+        ).All()
+        response = client.Send(query)
+        self.assertEqual(len(response.result['result']), 2)
+
+
+    def test_d_delete_quads(self):
+        client = CayleyClient(_CLIENT_URL)
+        response = client.DeleteQuads([
+            ('foo', 'to', 'bar'),
+            ('baz', 'from', 'quux')
+        ])
+        self.assertEqual(response.r.status_code, 200)
+
+        g = GraphObject()
+
+        query = g.V("foo").Out('to').Is("bar").Union(
+            g.V("baz").Out('from').Is('quux')
+        ).All()
+        response = client.Send(query)
+        self.assertIsNone(response.result['result'])


### PR DESCRIPTION
This pull request is an attempt to support adding/removing quads (#14).

I struggled to pick appropriate method names. In the official go client there's a single version (AddQuad) and plural version (AddQuadSet) for addition This pull request is an attempt to support adding/removing quads (#14).

I struggled to pick appropriate method names. In the official go client there's a single version (AddQuad) and plural version (AddQuadSet) for addition but only a single version (RemoveQuad) for removal. This immediately sounds weird. Also the HTTP api (write/delete) supports only batch operations.

I ended up providing both single and batch operations, and I picked the name DeleteQuad(s) in favor of RemoveQuad because it's built upon the HTTP api.but only a single version (RemoveQuad) for removal. This immediately sounds weird. Also the HTTP api (write/delete) supports only batch operations.

I ended up providing both single and batch operations, and I picked the name DeleteQuad(s) in favor of RemoveQuad because it's built upon the HTTP api.